### PR TITLE
feat: handle failing tx

### DIFF
--- a/ethtxmanager/config.go
+++ b/ethtxmanager/config.go
@@ -83,4 +83,8 @@ type Config struct {
 	// overwriting the default value provided by the network
 	// 0 means that the default value will be used
 	FinalizedStatusL1NumberOfBlocks uint64 `mapstructure:"FinalizedStatusL1NumberOfBlocks"`
+
+	// MaxRetries is the maximum number of times a transaction will be retried before being evicted
+	// 0 means unlimited retries (default behavior)
+	MaxRetries uint64 `mapstructure:"MaxRetries"`
 }

--- a/ethtxmanager/config.go
+++ b/ethtxmanager/config.go
@@ -84,7 +84,7 @@ type Config struct {
 	// 0 means that the default value will be used
 	FinalizedStatusL1NumberOfBlocks uint64 `mapstructure:"FinalizedStatusL1NumberOfBlocks"`
 
-	// MaxRetries is the maximum number of times a transaction will be retried before being evicted
+	// MaxEstimateGasRetries is the maximum number of times a transaction will be retried before being evicted
 	// 0 means unlimited retries (default behavior)
-	MaxRetries uint64 `mapstructure:"MaxRetries"`
+	MaxEstimateGasRetries uint64 `mapstructure:"MaxEstimateGasRetries"`
 }

--- a/ethtxmanager/config.go
+++ b/ethtxmanager/config.go
@@ -84,7 +84,7 @@ type Config struct {
 	// 0 means that the default value will be used
 	FinalizedStatusL1NumberOfBlocks uint64 `mapstructure:"FinalizedStatusL1NumberOfBlocks"`
 
-	// MaxEstimateGasRetries is the maximum number of times a transaction will be retried before being evicted
+	// EstimateGasMaxRetries is the maximum number of times a transaction will be retried before being evicted
 	// 0 means unlimited retries (default behavior)
-	MaxEstimateGasRetries uint64 `mapstructure:"MaxEstimateGasRetries"`
+	EstimateGasMaxRetries uint64 `mapstructure:"EstimateGasMaxRetries"`
 }

--- a/ethtxmanager/ethtxmanager.go
+++ b/ethtxmanager/ethtxmanager.go
@@ -626,8 +626,8 @@ func (c *Client) monitorTx(ctx context.Context, mTx *monitoredTxnIteration, logg
 	logger.Info("processing")
 
 	// Check if max retries is configured and if this transaction has exceeded the limit
-	if c.cfg.MaxEstimateGasRetries > 0 && mTx.RetryCount >= c.cfg.MaxEstimateGasRetries {
-		logger.Debugf("transaction exceeded max retries (%d), evicting from tx manager", c.cfg.MaxEstimateGasRetries)
+	if c.cfg.EstimateGasMaxRetries > 0 && mTx.RetryCount >= c.cfg.EstimateGasMaxRetries {
+		logger.Debugf("transaction exceeded max retries (%d), evicting from tx manager", c.cfg.EstimateGasMaxRetries)
 		mTx.Status = types.MonitoredTxStatusEvicted
 		err = c.storage.Update(ctx, *mTx.MonitoredTx)
 		if err != nil {

--- a/ethtxmanager/ethtxmanager.go
+++ b/ethtxmanager/ethtxmanager.go
@@ -406,6 +406,7 @@ func (c *Client) buildResult(ctx context.Context, mTx types.MonitoredTx) (types.
 	txs := make(map[common.Hash]types.TxResult, len(history))
 
 	// Skip blockchain calls for evicted transactions - they were never successfully sent
+	// For evicted transactions, txs map remains empty
 	if mTx.Status != types.MonitoredTxStatusEvicted {
 		for _, txHash := range history {
 			tx, _, err := c.etherman.GetTx(ctx, txHash)
@@ -430,7 +431,6 @@ func (c *Client) buildResult(ctx context.Context, mTx types.MonitoredTx) (types.
 			}
 		}
 	}
-	// For evicted transactions, txs map remains empty
 
 	result := types.MonitoredTxResult{
 		ID:                 mTx.ID,

--- a/ethtxmanager/ethtxmanager.go
+++ b/ethtxmanager/ethtxmanager.go
@@ -627,7 +627,7 @@ func (c *Client) monitorTx(ctx context.Context, mTx *monitoredTxnIteration, logg
 
 	// Check if max retries is configured and if this transaction has exceeded the limit
 	if c.cfg.MaxRetries > 0 && mTx.RetryCount >= c.cfg.MaxRetries {
-		logger.Warnf("transaction exceeded max retries (%d), evicting from tx manager", c.cfg.MaxRetries)
+		logger.Debugf("transaction exceeded max retries (%d), evicting from tx manager", c.cfg.MaxRetries)
 		mTx.Status = types.MonitoredTxStatusEvicted
 		err = c.storage.Update(ctx, *mTx.MonitoredTx)
 		if err != nil {

--- a/ethtxmanager/ethtxmanager.go
+++ b/ethtxmanager/ethtxmanager.go
@@ -626,8 +626,8 @@ func (c *Client) monitorTx(ctx context.Context, mTx *monitoredTxnIteration, logg
 	logger.Info("processing")
 
 	// Check if max retries is configured and if this transaction has exceeded the limit
-	if c.cfg.MaxRetries > 0 && mTx.RetryCount >= c.cfg.MaxRetries {
-		logger.Debugf("transaction exceeded max retries (%d), evicting from tx manager", c.cfg.MaxRetries)
+	if c.cfg.MaxEstimateGasRetries > 0 && mTx.RetryCount >= c.cfg.MaxEstimateGasRetries {
+		logger.Debugf("transaction exceeded max retries (%d), evicting from tx manager", c.cfg.MaxEstimateGasRetries)
 		mTx.Status = types.MonitoredTxStatusEvicted
 		err = c.storage.Update(ctx, *mTx.MonitoredTx)
 		if err != nil {

--- a/ethtxmanager/sqlstorage/migrations/0002.sql
+++ b/ethtxmanager/sqlstorage/migrations/0002.sql
@@ -1,0 +1,9 @@
+-- +migrate Up
+ALTER TABLE monitored_txs ADD COLUMN retry_count BIGINT DEFAULT 0 NOT NULL;
+
+-- Add index for retry_count to optimize queries
+CREATE INDEX idx_monitored_txs_retry_count ON monitored_txs(retry_count);
+
+-- +migrate Down
+DROP INDEX IF EXISTS idx_monitored_txs_retry_count;
+ALTER TABLE monitored_txs DROP COLUMN retry_count;

--- a/types/monitored_tx.go
+++ b/types/monitored_tx.go
@@ -32,6 +32,9 @@ const (
 
 	// MonitoredTxStatusFinalized means the tx was already mined M (M > N) blocks ago
 	MonitoredTxStatusFinalized = MonitoredTxStatus("finalized")
+
+	// MonitoredTxStatusEvicted means the tx exceeded the maximum number of retries and was evicted
+	MonitoredTxStatusEvicted = MonitoredTxStatus("evicted")
 )
 
 // MonitoredTxStatus represents the status of a monitored tx
@@ -102,6 +105,9 @@ type MonitoredTx struct {
 
 	// EstimateGas indicates whether gas should be estimated or the last value should be reused
 	EstimateGas bool `mapstructure:"estimateGas" meddler:"estimate_gas"`
+
+	// RetryCount tracks the number of times this transaction has been retried
+	RetryCount uint64 `mapstructure:"retryCount" meddler:"retry_count"`
 }
 
 // Tx uses the current information to build a tx


### PR DESCRIPTION
Closes https://github.com/agglayer/aggkit/issues/942

### What does this PR do?
Currently, the transaction manager calls the [EstimateGas](https://github.com/0xPolygon/zkevm-ethtx-manager/blob/main/ethtxmanager/ethtxmanager.go#L874) method for every transaction. However, if a transaction is bound to fail, the gas estimation also fails. Such transactions remain stuck in the monitor state, causing the system to repeatedly retry estimating gas for them, which is problematic.

With this PR, I’ve introduced a new transaction state called `evicted`. Transactions that consistently fail gas estimation will now transition into the evicted state, preventing unnecessary retries.


