### PR TITLE
fix: increment RetryCount on reverted tx receipt to prevent infinite loop

### DIFF
--- a/ethtxmanager/ethtxmanager.go
+++ b/ethtxmanager/ethtxmanager.go
@@ -768,6 +768,11 @@ func (c *Client) monitorTx(ctx context.Context, mTx *monitoredTxnIteration, logg
 		// if we should continue to monitor, we move to the next one and this will
 		// be reviewed in the next monitoring cycle
 		if c.shouldContinueToMonitorThisTx(ctx, mTx.lastReceipt) {
+			mTx.RetryCount++
+			logger.Debugf("incremented retry count to %d after reverted tx receipt", mTx.RetryCount)
+			if updateErr := c.storage.Update(ctx, *mTx.MonitoredTx); updateErr != nil {
+				logger.Errorf("failed to update retry count after reverted receipt: %v", updateErr)
+			}
 			return
 		}
 		// otherwise we understand this monitored tx has failed

--- a/ethtxmanager/ethtxmanager_test.go
+++ b/ethtxmanager/ethtxmanager_test.go
@@ -548,3 +548,75 @@ func TestMonitorTxSendFailureRetryIncrement(t *testing.T) {
 		require.Equal(t, uint64(2), mTx.RetryCount)
 	})
 }
+
+func TestMonitorTxRevertedReceiptRetryIncrement(t *testing.T) {
+	t.Run("Reverted receipt - increments retry count", func(t *testing.T) {
+		testData := newTestData(t, true)
+		testData.sut.cfg.EstimateGasMaxRetries = 10
+
+		revertedReceipt := &ethtypes.Receipt{
+			Status: ethtypes.ReceiptStatusFailed,
+			TxHash: common.HexToHash("0xabc"),
+		}
+
+		mTx := &monitoredTxnIteration{
+			MonitoredTx: &types.MonitoredTx{
+				ID:         common.HexToHash("0x123"),
+				Status:     types.MonitoredTxStatusSent,
+				RetryCount: 3,
+				Value:      big.NewInt(0),
+				Data:       []byte{},
+				Gas:        21000,
+				GasPrice:   big.NewInt(1000000000),
+				History:    make(map[common.Hash]bool),
+			},
+			confirmed:   true,
+			lastReceipt: revertedReceipt,
+		}
+
+		// GetTx succeeds, GetRevertMessage returns ErrExecutionReverted
+		testData.ethermanMock.EXPECT().GetTx(testData.ctx, revertedReceipt.TxHash).
+			Return(ethtypes.NewTx(&ethtypes.LegacyTx{}), false, nil).Once()
+		testData.ethermanMock.EXPECT().GetRevertMessage(testData.ctx, mock.Anything).
+			Return("", ErrExecutionReverted).Once()
+
+		// Storage update for retry count increment
+		testData.storageMock.EXPECT().Update(testData.ctx, mock.MatchedBy(func(tx types.MonitoredTx) bool {
+			return tx.RetryCount == 4
+		})).Return(nil).Once()
+
+		logger := createMonitoredTxLogger(*mTx.MonitoredTx)
+		testData.sut.monitorTx(testData.ctx, mTx, logger)
+
+		require.Equal(t, uint64(4), mTx.RetryCount)
+		require.Equal(t, types.MonitoredTxStatusSent, mTx.Status, "Status should remain sent for retry")
+	})
+
+	t.Run("Reverted receipt - evicted after max retries", func(t *testing.T) {
+		testData := newTestData(t, true)
+		testData.sut.cfg.EstimateGasMaxRetries = 5
+
+		mTx := &monitoredTxnIteration{
+			MonitoredTx: &types.MonitoredTx{
+				ID:         common.HexToHash("0x456"),
+				Status:     types.MonitoredTxStatusSent,
+				RetryCount: 5,
+				Value:      big.NewInt(0),
+				Data:       []byte{},
+				Gas:        21000,
+				GasPrice:   big.NewInt(1000000000),
+				History:    make(map[common.Hash]bool),
+			},
+		}
+
+		// Should be evicted before reaching shouldContinueToMonitorThisTx
+		testData.storageMock.EXPECT().Update(testData.ctx, mock.MatchedBy(func(tx types.MonitoredTx) bool {
+			return tx.Status == types.MonitoredTxStatusEvicted
+		})).Return(nil).Once()
+
+		logger := createMonitoredTxLogger(*mTx.MonitoredTx)
+		testData.sut.monitorTx(testData.ctx, mTx, logger)
+
+		require.Equal(t, types.MonitoredTxStatusEvicted, mTx.Status)
+	})
+}


### PR DESCRIPTION
## Summary

Increment RetryCount when shouldContinueToMonitorThisTx returns true (reverted tx with generic ErrExecutionReverted). This allows EstimateGasMaxRetries to evict the tx after N attempts instead of looping forever.

Fixes #132

## Changes

- `ethtxmanager/ethtxmanager.go`: 5 lines — increment RetryCount + persist to storage
- `ethtxmanager/ethtxmanager_test.go`: 2 test cases — retry increment + eviction

## Test plan

- [x] All 13 tests pass
- [x] Verified fix recovers stuck pipeline in production